### PR TITLE
Add habtm/has_many :through support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ model.association.count
 
 ### Example
 
+#### has_many
+
 ```ruby
 class User < ApplicationRecord
   has_many :posts
@@ -80,6 +82,53 @@ class Types::UserType < Types::BaseObject
 
   def post_count
     AssociationCountLoader.for(User, :posts).load(object)
+  end
+end
+```
+
+#### has_and_belongs_to_many
+
+```ruby
+class User < ApplicationRecord
+  has_and_belongs_to_many :posts, inverse_of: :users
+end
+
+class Post < ApplicationRecord
+  has_and_belongs_to_many :users
+end
+
+class Types::UserType < Types::BaseObject
+  field :post_count, Integer
+
+  def post_count
+    AssociationCountLoader.for(User, :posts).load(object)
+  end
+end
+```
+
+#### has_many :through
+
+```ruby
+class User < ApplicationRecord
+  has_many :posts
+  has_many :comments, through: :posts, inverse_of: :user
+end
+
+class Post < ApplicationRecord
+  belongs_to :user
+  has_many :comments
+end
+
+class Comment < ApplicationRecord
+  belongs_to :post
+  has_one :user, through: :post
+end
+
+class Types::UserType < Types::BaseObject
+  field :comment_count, Integer
+
+  def comment_count
+    AssociationCountLoader.for(User, :comments).load(object)
   end
 end
 ```

--- a/loaders/association_count_loader.rb
+++ b/loaders/association_count_loader.rb
@@ -1,4 +1,7 @@
 class AssociationCountLoader < GraphQL::Batch::Loader
+  class MissingInverseOf < StandardError; end
+  class UnsupportedReflection < StandardError; end
+
   def initialize(model, association_name)
     super()
     @model = model
@@ -11,7 +14,21 @@ class AssociationCountLoader < GraphQL::Batch::Loader
 
     klass = reflection.klass
     field = reflection.join_primary_key
-    counts = klass.where(field => records).group(field).count
+
+    # has_many
+    if reflection.instance_of?(ActiveRecord::Reflection::HasManyReflection)
+      counts = klass.where(field => records).group(field).count
+    # has_and_belongs_to_many, has_many :through
+    elsif reflection.instance_of?(ActiveRecord::Reflection::HasAndBelongsToManyReflection) || reflection.instance_of?(ActiveRecord::Reflection::ThroughReflection)
+      if reflection.inverse_of.nil?
+        raise MissingInverseOf, "`#{@model}` does not have inverse of `#{@model}##{reflection.name}`."
+      end
+
+      primary_key = reflection.inverse_of.association_primary_key.to_sym
+      counts = klass.joins(reflection.inverse_of.name).where(reflection.inverse_of.name => { primary_key => records.map(&primary_key) }).group(reflection.inverse_of.foreign_key).count
+    else
+      raise UnsupportedReflection, "`#{reflection.class}` is not supported by AssociationCountLoader"
+    end
 
     records.each do |record|
       record_key = record[reflection.active_record_primary_key]


### PR DESCRIPTION
Hello 🙂

According to https://www.rubydoc.info/gems/activerecord/ActiveRecord/Reflection/AbstractReflection
"Countable" associations are :
- has_many
- has_and_belongs_to_many
- has_many :through

The current AssociationCountLoader works for has_many associations, but not for the other 2.

I added an implementation for habtm/has_many through which relies on `joins` with the association name (which should automatically go through all intermediate associations) + `where` with association name: primary key => array of primary keys (which should automatically create the where clause).

It also relies on an `inverse_of` definition, inspired by [activerecord-precounter gem](https://github.com/k0kubun/activerecord-precounter/blob/master/lib/active_record/precounter.rb). I also added two errors (also inspired from the gem) in case of missing inverse_of, or in case of unhandled association.

Note: the activerecord-precounter gem also handles association scopes, which could be added to this loader.